### PR TITLE
Ajuste para evitar duplicidade de atendimentos

### DIFF
--- a/Busca Ativa - Gestantes/gestante_busca_ativa.sql
+++ b/Busca Ativa - Gestantes/gestante_busca_ativa.sql
@@ -276,7 +276,10 @@ SELECT v3.estabelecimento_cnes,
                     /* Pega a primeira data de atendimento não nula (ordenada pela data de atendimento) a partir do campo co_dim_tempo_dum da ficha de atendimento individual (tb_fat_atendimento_individual), repartido a partir de nome da gestante e data de nascimento */
                     min(v1.atendimento_data) FILTER (WHERE v1.gestante_dpp IS NOT NULL) OVER (PARTITION BY v1.gestante_nome, v1.gestante_data_de_nascimento) AS atendimento_primeiro_data
                     FROM ( 
-                            SELECT tdt.dt_registro AS atendimento_data,
+                            SELECT
+                            /* Faz distinct pela PK da tabela, para evitar registros duplicados caso o atendimento possua mais de 1 ou CID e/ou CIAP registrados */ 
+                            distinct(tfai.co_seq_fat_atd_ind),
+                            tdt.dt_registro AS atendimento_data,
                             /* Retorna código da unidade na Ficha de cadastro individual recente (tb_fat_cad_individual), caso nulo retorna código da unidade na Ficha de atendimento individual recente (tb_fat_atendimento_individual) */
                             COALESCE(NULLIF(unidadecadastrorecente.nu_cnes, '-'), unidadeatendimentorecente.nu_cnes) AS estabelecimento_cnes,
                             /* Retorna nome da unidade na Ficha de cadastro individual recente (tb_fat_cad_individual), caso nulo retorna nome da unidade na Ficha de atendimento individual recente (tb_fat_atendimento_individual) */

--- a/Busca Ativa - Gestantes/gestante_busca_ativa.sql
+++ b/Busca Ativa - Gestantes/gestante_busca_ativa.sql
@@ -45,7 +45,7 @@ SELECT v3.estabelecimento_cnes,
             WHEN v3.possui_registro_parto IS TRUE THEN 'Sim'
             ELSE 'Não'
         END AS possui_registro_parto,
-   CURRENT_TIMESTAMP as atualizacao_data 
+   CURRENT_TIMESTAMP as criacao_data 
    FROM ( SELECT row_number() OVER (PARTITION BY v2.gestante_nome, v2.gestante_data_de_nascimento ORDER BY v2.atendimento_data DESC) AS r,
             v2.atendimento_data,
             v2.atendimento_primeiro_data,


### PR DESCRIPTION
Ajuste para evitar duplicidade de atendimentos em caso de registro de mais de um CID10 e/ou CIAP vinculado ao atendimento individual